### PR TITLE
[SHELL32] Handle the Progman Folder options message and tab switching support

### DIFF
--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -192,10 +192,13 @@ HBITMAP CreateRadioMask(HDC hDC)
 
 // CMSGlobalFolderOptionsStub --- The owner window of Folder Options.
 // This window hides taskbar button of Folder Options.
+
+#define GlobalFolderOptionsClassName _T("MSGlobalFolderOptionsStub")
+
 class CMSGlobalFolderOptionsStub : public CWindowImpl<CMSGlobalFolderOptionsStub>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("MSGlobalFolderOptionsStub"), 0, COLOR_WINDOWTEXT)
+    DECLARE_WND_CLASS_EX(GlobalFolderOptionsClassName, 0, COLOR_WINDOWTEXT)
 
     BEGIN_MSG_MAP(CMSGlobalFolderOptionsStub)
     END_MSG_MAP()
@@ -222,8 +225,10 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
     return 0;
 }
 
-static VOID
-ShowFolderOptionsDialog(HWND hWnd, HINSTANCE hInst)
+enum { PAGE_GENERAL, PAGE_VIEW, PAGE_FILETYPES };
+
+static DWORD CALLBACK
+ShowFolderOptionsDialogThreadProc(LPVOID param)
 {
     PROPSHEETHEADERW pinfo;
     HPROPSHEETPAGE hppages[3];
@@ -254,7 +259,7 @@ ShowFolderOptionsDialog(HWND hWnd, HINSTANCE hInst)
     if (!stub.Create(NULL, NULL, NULL, style, exstyle))
     {
         ERR("stub.Create failed\n");
-        return;
+        return 0;
     }
 
     memset(&pinfo, 0x0, sizeof(PROPSHEETHEADERW));
@@ -266,10 +271,34 @@ ShowFolderOptionsDialog(HWND hWnd, HINSTANCE hInst)
     pinfo.pszIcon = MAKEINTRESOURCEW(IDI_SHELL_FOLDER_OPTIONS);
     pinfo.pszCaption = szOptions;
     pinfo.pfnCallback = PropSheetProc;
+    pinfo.nStartPage = (UINT) param;
 
     PropertySheetW(&pinfo);
 
     stub.DestroyWindow();
+    return 0;
+}
+
+VOID WINAPI 
+ShowFolderOptionsDialog(UINT Page, BOOL Async = false)
+{
+    HWND hWnd = FindWindow(GlobalFolderOptionsClassName, NULL);
+    if (hWnd)
+    {
+        HWND hPop = GetLastActivePopup(hWnd);
+        if (hWnd == GetParent(hPop))
+        {
+            PostMessage(hPop, PSM_SETCURSEL, Page, 0);
+        }
+        SetForegroundWindow(hPop);
+        return ;
+    }
+    
+    LPVOID param = (LPVOID) Page;
+    if (Async)
+        SHCreateThread(ShowFolderOptionsDialogThreadProc, param, 0, 0);
+    else
+        ShowFolderOptionsDialogThreadProc(param); // Rundll32 caller cannot be async!
 }
 
 static VOID
@@ -278,13 +307,15 @@ Options_RunDLLCommon(HWND hWnd, HINSTANCE hInst, int fOptions, DWORD nCmdShow)
     switch(fOptions)
     {
         case 0:
-            ShowFolderOptionsDialog(hWnd, hInst);
+            ShowFolderOptionsDialog(PAGE_GENERAL);
             break;
 
-        case 1:
-            // show taskbar options dialog
-            FIXME("notify explorer to show taskbar options dialog\n");
-            //PostMessage(GetShellWindow(), WM_USER+22, fOptions, 0);
+        case 1: // Show taskbar options dialog
+            PostMessage(GetShellWindow(), WM_USER+22, fOptions, 0);
+            break;
+
+        case 7: // Windows 8, 10
+            ShowFolderOptionsDialog(PAGE_VIEW);
             break;
 
         default:

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -85,6 +85,7 @@ public:
     LRESULT OnCommand(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnSetFocus(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnGetChangeNotifyServer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+    LRESULT OnShowOptionsDlg(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
 
 DECLARE_WND_CLASS_EX(szProgmanClassName, CS_DBLCLKS, COLOR_DESKTOP)
 
@@ -98,6 +99,7 @@ BEGIN_MSG_MAP(CBaseBar)
     MESSAGE_HANDLER(WM_COMMAND, OnCommand)
     MESSAGE_HANDLER(WM_SETFOCUS, OnSetFocus)
     MESSAGE_HANDLER(WM_DESKTOP_GET_CNOTIFY_SERVER, OnGetChangeNotifyServer)
+    MESSAGE_HANDLER(WM_USER+22, OnShowOptionsDlg)
 END_MSG_MAP()
 
 BEGIN_COM_MAP(CDesktopBrowser)
@@ -456,6 +458,22 @@ LRESULT CDesktopBrowser::OnGetChangeNotifyServer(UINT uMsg, WPARAM wParam, LPARA
             return NULL;
     }
     return (LRESULT)m_hwndChangeNotifyServer;
+}
+
+extern VOID WINAPI ShowFolderOptionsDialog(UINT Page, BOOL Async);
+
+LRESULT CDesktopBrowser::OnShowOptionsDlg(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
+{
+    switch(wParam)
+    {
+    case 0:
+        ShowFolderOptionsDialog(0, true);
+        break;
+    case 1:
+        _NotifyTray(WM_COMMAND, TRAYCMD_TASKBAR_PROPERTIES, 0);
+        break;
+    }
+    return 0;
 }
 
 HRESULT CDesktopBrowser_CreateInstance(IShellDesktopTray *Tray, REFIID riid, void **ppv)


### PR DESCRIPTION
Options_RunDLL is supposed to reuse the same window.

On newer Windows versions, tab switching is also supported:

````bat
rundll32 shell32.dll,Options_RunDLL 0& REM General tab
ping localhost
rundll32 shell32.dll,Options_RunDLL 7& REM View tab
REM Should be on the View tab now
````