### PR TITLE
[SHELL32] Support more FOLDERFLAGS in DefView

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -628,19 +628,27 @@ void CDefView::UpdateStatusbar()
 BOOL CDefView::CreateList()
 {
     HRESULT hr;
-    DWORD dwStyle, dwExStyle;
+    DWORD dwStyle, dwExStyle, ListExStyle;
     UINT ViewMode;
 
     TRACE("%p\n", this);
 
     dwStyle = WS_TABSTOP | WS_VISIBLE | WS_CHILDWINDOW | WS_CLIPSIBLINGS | WS_CLIPCHILDREN |
-              LVS_SHAREIMAGELISTS | LVS_EDITLABELS | LVS_AUTOARRANGE;
+              LVS_SHAREIMAGELISTS | LVS_EDITLABELS | LVS_AUTOARRANGE; // FIXME: Why is LVS_AUTOARRANGE here?
     dwExStyle = WS_EX_CLIENTEDGE;
+    ListExStyle = 0;
 
     if (m_FolderSettings.fFlags & FWF_DESKTOP)
+    {
+        m_FolderSettings.fFlags |= FWF_NOCLIENTEDGE | FWF_NOSCROLL;
         dwStyle |= LVS_ALIGNLEFT;
+    }
     else
-        dwStyle |= LVS_ALIGNTOP | LVS_SHOWSELALWAYS;
+    {
+        dwStyle |= LVS_SHOWSELALWAYS; // MSDN says FWF_SHOWSELALWAYS is deprecated, always turn on for folders.
+        dwStyle |= (m_FolderSettings.fFlags & FWF_ALIGNLEFT) ? LVS_ALIGNLEFT : LVS_ALIGNTOP;
+        ListExStyle = LVS_EX_DOUBLEBUFFER;
+    }
 
     ViewMode = m_FolderSettings.ViewMode;
     hr = _DoFolderViewCB(SFVM_DEFVIEWMODE, 0, (LPARAM)&ViewMode);
@@ -679,13 +687,26 @@ BOOL CDefView::CreateList()
         dwStyle |= LVS_AUTOARRANGE;
 
     if (m_FolderSettings.fFlags & FWF_SNAPTOGRID)
-        dwExStyle |= LVS_EX_SNAPTOGRID;
-
-    if (m_FolderSettings.fFlags & FWF_DESKTOP)
-        m_FolderSettings.fFlags |= FWF_NOCLIENTEDGE | FWF_NOSCROLL;
+        ListExStyle |= LVS_EX_SNAPTOGRID;
 
     if (m_FolderSettings.fFlags & FWF_SINGLESEL)
         dwStyle |= LVS_SINGLESEL;
+
+    if (m_FolderSettings.fFlags & FWF_FULLROWSELECT)
+        ListExStyle |= LVS_EX_FULLROWSELECT;
+
+    if (m_FolderSettings.fFlags & FWF_SINGLECLICKACTIVATE)
+        ListExStyle |= LVS_EX_TRACKSELECT | LVS_EX_ONECLICKACTIVATE;
+
+    if (m_FolderSettings.fFlags & FWF_NOCOLUMNHEADER)
+        dwStyle |= LVS_NOCOLUMNHEADER;
+
+#if 0
+    // FIXME: Because this is a negative, everyone gets the new flag by default unless they
+    // opt out. This code should be enabled when the shell looks like Vista instead of 2003.
+    if (!(m_FolderSettings.fFlags & FWF_NOHEADERINALLVIEWS))
+        ListExStyle |= LVS_EX_HEADERINALLVIEWS;
+#endif
 
     if (m_FolderSettings.fFlags & FWF_NOCLIENTEDGE)
         dwExStyle &= ~WS_EX_CLIENTEDGE;
@@ -695,6 +716,8 @@ BOOL CDefView::CreateList()
 
     if (!m_ListView)
         return FALSE;
+
+    ListView_SetExtendedListViewStyle(m_ListView.m_hWnd, ListExStyle);
 
     m_sortInfo.bIsAscending = TRUE;
     m_sortInfo.nHeaderID = -1;


### PR DESCRIPTION
This adds support for more of the FOLDERSETTINGS FOLDERFLAGS.

 - Turned on LVS_EX_DOUBLEBUFFER even though there is no setting for it. XP has it on for folders but not the desktop and this matches that. Vista might turn it on for its shadow labels on the desktop, further investigation required.
 - Fixes a bug where LVS_EX_SNAPTOGRID was incorrectly assigned where the WS_EX flags go.
 - LVS_AUTOARRANGE seems to be incorrectly forced on but for compatibility I decided to leave it but added a comment. The existing code already has the check for FWF_AUTOARRANGE.